### PR TITLE
Fixed error message for renaming stage.

### DIFF
--- a/client/src/redux/tasks/tasks.sagas.ts
+++ b/client/src/redux/tasks/tasks.sagas.ts
@@ -102,6 +102,12 @@ function* attemptModifyTasks({ payload }: EditTasksStartAction) {
 	try {
 		// Tasks is an array of all the modified tasks
 		const tasks = payload;
+
+		// If the payload is empty, do nothing
+		if (tasks.length === 0) {
+			return;
+		}
+
 		yield put(editTasksSuccess(tasks));
 
 		if (!Array.isArray(payload)) {


### PR DESCRIPTION
This was caused by trying to pull the projectId from the first element of a potentially empty task array.